### PR TITLE
Replaced dls-controls with DiamondLightSource

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,10 +24,10 @@ parser = PMACParser(code_lines)
 
 output_vars = parser.parse(input_vars)
 
-.. |Build Status| image:: https://api.travis-ci.org/dls-controls/pmacparser.svg
-    :target: https://travis-ci.org/dls-controls/pmacparser
-.. |Coverage Status| image:: https://coveralls.io/repos/github/dls-controls/pmacparser/badge.svg?branch=master
-    :target: https://coveralls.io/github/dls-controls/pmacparser?branch=master
-.. |Code Health| image:: https://landscape.io/github/dls-controls/pmacparser/master/landscape.svg?style=flat
-    :target: https://landscape.io/github/dls-controls/pmacparser/master
+.. |Build Status| image:: https://api.travis-ci.org/DiamondLightSource/pmacparser.svg
+    :target: https://travis-ci.org/DiamondLightSource/pmacparser
+.. |Coverage Status| image:: https://coveralls.io/repos/github/DiamondLightSource/pmacparser/badge.svg?branch=master
+    :target: https://coveralls.io/github/DiamondLightSource/pmacparser?branch=master
+.. |Code Health| image:: https://landscape.io/github/DiamondLightSource/pmacparser/master/landscape.svg?style=flat
+    :target: https://landscape.io/github/DiamondLightSource/pmacparser/master
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     version=get_version(),
     description='PMAC parser and kinematics emulator',
     long_description=open("README.rst").read(),
-    url='https://github.com/dls-controls/pmacparser',
+    url='https://github.com/DiamondLightSource/pmacparser',
     author='Matt Taylor',
     author_email='matthew.taylor@diamond.ac.uk',
     keywords='',


### PR DESCRIPTION
Repository was automatically transferred from `dls-controls/pmacparser` using https://gitlab.diamond.ac.uk/github/github-scripts